### PR TITLE
Add the ability to exclude files from tests

### DIFF
--- a/packages/windmill-a11y/src/cli.ts
+++ b/packages/windmill-a11y/src/cli.ts
@@ -20,9 +20,10 @@ program
     .option('-d, --debug', `Debug mode`)
     .option('-w, --webpack <w>', `webpack path`)
     .option('-c, --config <c>', `Config file path`)
+    .option('-x, --exclude <x>', `Test glob to exclude`)
     .parse(process.argv);
 
-const { args, project, webpack, impactLevel, debug, config } = program;
+const { args, project, webpack, impactLevel, debug, config, exclude } = program;
 const projectPath = (project as string) || process.cwd();
 const windmillConfigPath = (config as string) || fs.findClosestFileSync(projectPath, 'windmill.config.js');
 
@@ -47,7 +48,8 @@ if (!webpackConfigPath) {
 
 const simulations: string[] = [];
 const simulationFilePattern = windmillConfig?.simulationFilePattern || ['*.sim.ts', '*.sim.tsx'];
-const globOptions: glob.IOptions = { absolute: true, cwd: projectPath, matchBase: true };
+const ignorePaths = windmillConfig?.ignorePaths ? windmillConfig?.ignorePaths : exclude ? [exclude] : [];
+const globOptions: glob.IOptions = { absolute: true, cwd: projectPath, matchBase: true, ignore: ignorePaths };
 
 if (args.length > 0) {
     for (const arg of args) {

--- a/packages/windmill-a11y/test/a11y-cli.unit.ts
+++ b/packages/windmill-a11y/test/a11y-cli.unit.ts
@@ -40,4 +40,12 @@ describe('The a11y cli', function () {
         expect(stdout).to.include('No errors found');
         expect(status).to.equal(0);
     });
+
+    it('should ignore simulation files when using --exclude', () => {
+        const sim = 'image-with-alt.sim.ts';
+        const { stderr, status } = runA11y(['--exclude', `**/${sim}`, `${sim}`]);
+
+        expect(stderr).to.include(`Could not find any simulations matching the pattern: ${sim}`);
+        expect(status).to.equal(1);
+    });
 });

--- a/packages/windmill-sanity/src/cli.ts
+++ b/packages/windmill-sanity/src/cli.ts
@@ -15,9 +15,10 @@ program
     .option('-d, --debug', `Debug mode`)
     .option('-w, --webpack <w>', `webpack path`)
     .option('-c, --config <c>', `Config file path`)
+    .option('-x, --exclude <x>', `Test glob to exclude`)
     .parse(process.argv);
 
-const { args, project, webpack, debug, config } = program;
+const { args, project, webpack, debug, config, exclude } = program;
 
 const projectPath = (project as string) || process.cwd();
 const webpackConfigPath = (webpack as string) || getWebpackConfigPath(projectPath);
@@ -42,7 +43,8 @@ if (!webpackConfigPath) {
 
 const simulations: string[] = [];
 const defaultSimulationPattern = ['*.sim.ts', '*.sim.tsx'];
-const globOptions: glob.IOptions = { absolute: true, cwd: projectPath, matchBase: true };
+const ignorePaths = windmillConfig?.ignorePaths ? windmillConfig?.ignorePaths : exclude ? [exclude] : [];
+const globOptions: glob.IOptions = { absolute: true, cwd: projectPath, matchBase: true, ignore: ignorePaths };
 
 if (args.length > 0) {
     for (const arg of args) {

--- a/packages/windmill-sanity/test/sanity-cli.unit.ts
+++ b/packages/windmill-sanity/test/sanity-cli.unit.ts
@@ -50,4 +50,12 @@ describe('The sanity cli', function () {
         expect(stdout).to.include('This is a hook that gets called before loading your simulations');
         expect(status).to.equal(0);
     });
+
+    it('should ignore simulation files when using --exclude', () => {
+        const sim = 'image-with-alt.sim.ts';
+        const { stderr, status } = runSanity(['--exclude', `**/${sim}`, `${sim}`]);
+
+        expect(stderr).to.include(`Could not find any simulations matching the pattern: ${sim}`);
+        expect(status).to.equal(1);
+    });
 });

--- a/packages/windmill-utils/src/types.ts
+++ b/packages/windmill-utils/src/types.ts
@@ -25,5 +25,6 @@ export interface WindmillConfig {
     webpackConfigPath: string;
     hooks: [() => void];
     simulationFilePattern: string[];
+    ignorePaths: string[];
     a11yImpactLevel: axe.ImpactValue;
 }


### PR DESCRIPTION
Added a new CLI option `-x, --exclude`, and added the option to configure ignore paths in the `windmill.config.js` file too.